### PR TITLE
Create Image fix

### DIFF
--- a/src/main/java/org/openstack/api/images/ImagesResource.java
+++ b/src/main/java/org/openstack/api/images/ImagesResource.java
@@ -54,11 +54,11 @@ public class ImagesResource extends Resource {
 	public Image post(InputStream imageStream, long size, Image imageProperties) throws OpenstackException, IOException {
 	
 		Builder b = target.request(MediaType.APPLICATION_JSON);
-		
-		GlanceHeaderUtils.setHeaders(b, imageProperties);
 		byte[] bytes = IOUtils.toByteArray(imageStream);
 		imageProperties.setSize((long) bytes.length);
-		System.out.println(bytes.length);
+		
+		GlanceHeaderUtils.setHeaders(b, imageProperties);
+
 
 		return b.post(Entity.entity(bytes, MediaType.APPLICATION_OCTET_STREAM_TYPE), GlanceImage.class);
 	}

--- a/src/main/java/org/openstack/client/OpenStackClient.java
+++ b/src/main/java/org/openstack/client/OpenStackClient.java
@@ -160,7 +160,7 @@ public class OpenStackClient {
 	}
 	
 	public ImagesResource getImagesEndpoint() {
-		return target(access.getEndpoint("image", null).getPublicURL().concat("/images"), ImagesResource.class);
+		return target(access.getEndpoint("image", null).getPublicURL().concat("/v1/images"), ImagesResource.class);
 	}
 	
 	public ImagesResource getImagesInternalEndpoint() {


### PR DESCRIPTION
Fixed create image. It used to return http 300, because we were sending POST request to ip:9292/images instead ip:9292/v1/images
