### PR TITLE
Change data type of "size" in Image.java (nova-model)

### DIFF
--- a/nova-model/src/main/java/org/openstack/nova/model/Image.java
+++ b/nova-model/src/main/java/org/openstack/nova/model/Image.java
@@ -28,7 +28,7 @@ public class Image implements Serializable {
 	private Calendar updated;
 	
 	@JsonProperty("OS-EXT-IMG-SIZE:size")
-	private Integer size;
+	private Long size;
 	
 	private Map<String, String> metadata;
 		
@@ -156,7 +156,7 @@ public class Image implements Serializable {
 	/**
 	 * @return the size
 	 */
-	public Integer getSize() {
+	public Long getSize() {
 		return size;
 	}
 


### PR DESCRIPTION
The data type of "size" should be changed to "Long", because "Integer" will cause an error for large images as follows: 
  "...Numeric value (20700856320) out of range of int..."
