### PR TITLE
Change data type of "size" in Image.java (glance-model)

### DIFF
--- a/glance-model/src/main/java/org/openstack/glance/model/Image.java
+++ b/glance-model/src/main/java/org/openstack/glance/model/Image.java
@@ -23,7 +23,7 @@ public class Image implements Serializable {
 	@JsonProperty("container_format")
 	private String containerFormat;
 	
-	private Integer size;
+	private Long size;
 	
 	private String checksum;
 	
@@ -130,14 +130,14 @@ public class Image implements Serializable {
 	/**
 	 * @return the size
 	 */
-	public Integer getSize() {
+	public Long getSize() {
 		return size;
 	}
 
 	/**
 	 * @param size the size to set
 	 */
-	public void setSize(Integer size) {
+	public void setSize(Long size) {
 		this.size = size;
 	}
 


### PR DESCRIPTION
The data type of "size" should be changed to "Long", because "Integer" will cause an error for large images as follows: 
  "...Numeric value (20700856320) out of range of int..."
