### PR TITLE
connectors: add the RESTEasyConnector

### DIFF
--- a/openstack-client-connectors/pom.xml
+++ b/openstack-client-connectors/pom.xml
@@ -11,6 +11,7 @@
 	<modules>
 		<module>jersey-connector</module>
 		<module>jersey2-connector</module>
+		<module>resteasy-connector</module>
 	</modules>
 	<dependencies>
 		<dependency>

--- a/openstack-client-connectors/resteasy-connector/pom.xml
+++ b/openstack-client-connectors/resteasy-connector/pom.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.openstack</groupId>
+    <artifactId>openstack-client-connectors</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>resteasy-connector</artifactId>
+  <dependencies>
+  	<dependency>
+  		<groupId>org.jboss.resteasy</groupId>
+  		<artifactId>resteasy-jaxrs</artifactId>
+  		<version>2.3.2.Final</version>
+  	</dependency>
+  	<dependency>
+  		<groupId>org.jboss.resteasy</groupId>
+  		<artifactId>resteasy-jackson-provider</artifactId>
+  		<version>2.3.2.Final</version>
+  	</dependency>
+  	<dependency>
+  		<groupId>org.jboss.resteasy</groupId>
+  		<artifactId>resteasy-jettison-provider</artifactId>
+  		<version>2.3.2.Final</version>
+  	</dependency>
+  </dependencies>
+</project>

--- a/openstack-client-connectors/resteasy-connector/src/main/java/org/openstack/connector/RESTEasyConnector.java
+++ b/openstack-client-connectors/resteasy-connector/src/main/java/org/openstack/connector/RESTEasyConnector.java
@@ -1,0 +1,83 @@
+package org.openstack.connector;
+
+import java.util.List;
+import java.util.Map.Entry;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ContextResolver;
+
+import org.codehaus.jackson.map.DeserializationConfig;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.SerializationConfig;
+import org.codehaus.jackson.map.annotate.JsonRootName;
+import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
+import org.jboss.resteasy.client.ClientRequest;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.openstack.base.client.OpenStackClientConnector;
+import org.openstack.base.client.OpenStackRequest;
+
+import com.google.common.reflect.TypeToken;
+
+public class RESTEasyConnector implements OpenStackClientConnector {
+
+	public static ObjectMapper DEFAULT_MAPPER;
+
+	public static ObjectMapper WRAPPED_MAPPER;
+
+	static {
+		DEFAULT_MAPPER = new ObjectMapper();
+
+		DEFAULT_MAPPER.setSerializationInclusion(Inclusion.NON_NULL);
+		DEFAULT_MAPPER.enable(SerializationConfig.Feature.INDENT_OUTPUT);
+		DEFAULT_MAPPER.enable(DeserializationConfig.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+
+		WRAPPED_MAPPER = new ObjectMapper();
+
+		WRAPPED_MAPPER.setSerializationInclusion(Inclusion.NON_NULL);
+		WRAPPED_MAPPER.enable(SerializationConfig.Feature.INDENT_OUTPUT);
+		WRAPPED_MAPPER.enable(SerializationConfig.Feature.WRAP_ROOT_VALUE);
+		WRAPPED_MAPPER.enable(DeserializationConfig.Feature.UNWRAP_ROOT_VALUE);
+		WRAPPED_MAPPER.enable(DeserializationConfig.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+
+		ResteasyProviderFactory.getInstance().addContextResolver(new ContextResolver<ObjectMapper>() {
+			public ObjectMapper getContext(Class<?> type) {
+				return type.getAnnotation(JsonRootName.class) == null ? DEFAULT_MAPPER : WRAPPED_MAPPER;
+			}
+		});
+	}
+
+	@Override
+	public <T> T execute(OpenStackRequest request, Class<T> responseType) {
+		ClientRequest client = new ClientRequest(request.endpoint() + "/" + request.path());
+
+		for(Entry<String, List<Object>> h : request.headers().entrySet()) {
+			StringBuilder sb = new StringBuilder();
+			for(Object v : h.getValue()) {
+				sb.append(String.valueOf(v));
+			}
+			client.header(h.getKey(), sb);
+		}
+
+		if(request.entity() != null) {
+			client.body(request.entity().getContentType(), request.entity().getEntity());
+		}
+
+		try {
+			return (T) client.httpMethod(request.method(), responseType).getEntity(responseType);
+		} catch (Exception e) {
+			return null;
+		}
+	}
+
+	@Override
+	public void execute(OpenStackRequest request) {
+		execute(request, Response.class);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> T execute(OpenStackRequest request, TypeToken<T> typeToken) {
+		return (T) execute(request, typeToken.getClass());
+	}
+
+}


### PR DESCRIPTION
This patch introduces the support for the RESTEasy JAX-RS implementation
adding the RESTEasyConnector.

Signed-off-by: Federico Simoncelli fsimonce@redhat.com
