### PR TITLE
resteasy: use a specific ClientRequestFactory

### DIFF
--- a/openstack-client-connectors/resteasy-connector/pom.xml
+++ b/openstack-client-connectors/resteasy-connector/pom.xml
@@ -13,14 +13,9 @@
   		<version>2.3.2.Final</version>
   	</dependency>
   	<dependency>
-  		<groupId>org.jboss.resteasy</groupId>
-  		<artifactId>resteasy-jackson-provider</artifactId>
-  		<version>2.3.2.Final</version>
-  	</dependency>
-  	<dependency>
-  		<groupId>org.jboss.resteasy</groupId>
-  		<artifactId>resteasy-jettison-provider</artifactId>
-  		<version>2.3.2.Final</version>
+  		<groupId>org.codehaus.jackson</groupId>
+  		<artifactId>jackson-jaxrs</artifactId>
+  		<version>1.9.8</version>
   	</dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
In order to avoid collisions with other ObjectMappers defined by other
JSON providers, this patch introduces a specific ClientRequestFactory.

Signed-off-by: Federico Simoncelli fsimonce@redhat.com
