### PR TITLE
connectors: use ServiceLoader to select the default connector

### DIFF
--- a/ceilometer-client/src/main/java/org/openstack/ceilometer/CeilometerClient.java
+++ b/ceilometer-client/src/main/java/org/openstack/ceilometer/CeilometerClient.java
@@ -6,14 +6,14 @@ import org.openstack.base.client.OpenStackRequest;
 
 public class CeilometerClient extends OpenStackClient {
 	
+	public CeilometerClient(String endpoint) {
+		super(endpoint);
+	}
+
 	public CeilometerClient(String endpoint, OpenStackClientConnector connector) {
 		super(endpoint, connector);
 	}
 	
-	public CeilometerClient(String endpoint) {
-		super(endpoint, null);
-	}
-
 	public <R> R execute(CeilometerCommand<R> command) {
 		OpenStackRequest request = new OpenStackRequest();
 		request.endpoint(endpoint);

--- a/glance-client/src/main/java/org/openstack/glance/GlanceClient.java
+++ b/glance-client/src/main/java/org/openstack/glance/GlanceClient.java
@@ -6,6 +6,10 @@ import org.openstack.base.client.OpenStackRequest;
 
 public class GlanceClient extends OpenStackClient {
 	
+	public GlanceClient(String endpoint) {
+		super(endpoint);
+	}
+
 	public GlanceClient(String endpoint, OpenStackClientConnector connector) {
 		super(endpoint, connector);
 	}

--- a/keystone-client/src/main/java/org/openstack/keystone/KeystoneClient.java
+++ b/keystone-client/src/main/java/org/openstack/keystone/KeystoneClient.java
@@ -7,7 +7,7 @@ import org.openstack.base.client.OpenStackRequest;
 public class KeystoneClient extends OpenStackClient {
 	
 	public KeystoneClient(String endpoint) {
-		super(endpoint, null);
+		super(endpoint);
 	}
 	
 	public KeystoneClient(String endpoint, OpenStackClientConnector connector) {

--- a/nova-client/src/main/java/org/openstack/nova/NovaClient.java
+++ b/nova-client/src/main/java/org/openstack/nova/NovaClient.java
@@ -6,12 +6,12 @@ import org.openstack.base.client.OpenStackRequest;
 
 public class NovaClient extends OpenStackClient {
 	
+	public NovaClient(String endpoint) {
+		super(endpoint);
+	}
+
 	public NovaClient(String endpoint, OpenStackClientConnector connector) {
 		super(endpoint, connector);
-	}
-	
-	public NovaClient(String endpoint, String token) {
-		super(endpoint, null);
 	}
 
 	public <R> R execute(NovaCommand<R> command) {

--- a/openstack-client-connectors/jersey-connector/src/main/resources/META-INF/services/org.openstack.base.client.OpenStackClientConnector
+++ b/openstack-client-connectors/jersey-connector/src/main/resources/META-INF/services/org.openstack.base.client.OpenStackClientConnector
@@ -1,0 +1,1 @@
+org.openstack.connector.JerseyConnector

--- a/openstack-client-connectors/jersey2-connector/src/main/resources/META-INF/services/org.openstack.base.client.OpenStackClientConnector
+++ b/openstack-client-connectors/jersey2-connector/src/main/resources/META-INF/services/org.openstack.base.client.OpenStackClientConnector
@@ -1,0 +1,1 @@
+org.openstack.connector.JaxRs20Connector

--- a/openstack-client-connectors/resteasy-connector/src/main/resources/META-INF/services/org.openstack.base.client.OpenStackClientConnector
+++ b/openstack-client-connectors/resteasy-connector/src/main/resources/META-INF/services/org.openstack.base.client.OpenStackClientConnector
@@ -1,0 +1,1 @@
+org.openstack.connector.RESTEasyConnector

--- a/openstack-client/src/main/java/org/openstack/base/client/OpenStackClient.java
+++ b/openstack-client/src/main/java/org/openstack/base/client/OpenStackClient.java
@@ -1,6 +1,7 @@
 package org.openstack.base.client;
 
 import java.util.Properties;
+import java.util.ServiceLoader;
 
 public class OpenStackClient {
 	
@@ -12,9 +13,26 @@ public class OpenStackClient {
 	
 	protected Properties properties = new Properties();
 	
+	protected static OpenStackClientConnector DEFAULT_CONNECTOR;
+
+	static {
+		ServiceLoader<OpenStackClientConnector> connectorLoader;
+		connectorLoader = ServiceLoader.load(OpenStackClientConnector.class);
+
+		for (OpenStackClientConnector clientConnector : connectorLoader) {
+			DEFAULT_CONNECTOR = clientConnector;
+			break;
+		}
+	}
+
+	public OpenStackClient(String endpoint) {
+		this.endpoint = endpoint;
+		this.connector = DEFAULT_CONNECTOR;
+	}
+
 	public OpenStackClient(String endpoint, OpenStackClientConnector connector) {
 		this.endpoint = endpoint;
-		this.connector = connector;
+		this.connector = (connector == null) ? DEFAULT_CONNECTOR : connector;
 	}
 	
 	public <T> T execute(OpenStackCommand<T> command) {

--- a/openstack-examples/src/main/java/org/openstack/examples/ExamplesConfiguration.java
+++ b/openstack-examples/src/main/java/org/openstack/examples/ExamplesConfiguration.java
@@ -1,7 +1,5 @@
 package org.openstack.examples;
 
-import org.openstack.base.client.OpenStackClientConnector;
-import org.openstack.connector.JaxRs20Connector;
 import org.openstack.keystone.KeystoneClient;
 import org.openstack.keystone.api.CreateTenant;
 import org.openstack.keystone.api.DeleteTenant;
@@ -23,8 +21,7 @@ public class ExamplesConfiguration {
 	public static final String CEILOMETER_ENDPOINT = "";
 	
 	public static void main(String[] args) {
-		OpenStackClientConnector connector = new JaxRs20Connector();
-		KeystoneClient client = new KeystoneClient(KEYSTONE_ENDPOINT, connector);
+		KeystoneClient client = new KeystoneClient(KEYSTONE_ENDPOINT);
 		client.token("secret0");
 		client.execute(new DeleteTenant("36c481aec1d54fc49190c92c3ef6840a"));
 		Tenant tenant = client.execute(new CreateTenant(new Tenant("new_api")));

--- a/openstack-examples/src/main/java/org/openstack/examples/compute/NovaCreateServer.java
+++ b/openstack-examples/src/main/java/org/openstack/examples/compute/NovaCreateServer.java
@@ -40,7 +40,8 @@ public class NovaCreateServer {
 			access = keystone.execute(Authenticate.withToken(access.getToken().getId()).withTenantId(tenants.getList().get(0).getId()));
 			
 			//NovaClient novaClient = new NovaClient(KeystoneUtils.findEndpointURL(access.getServiceCatalog(), "compute", null, "public"), access.getToken().getId());
-			NovaClient novaClient = new NovaClient(ExamplesConfiguration.NOVA_ENDPOINT.concat(tenants.getList().get(0).getId()), access.getToken().getId());
+			NovaClient novaClient = new NovaClient(ExamplesConfiguration.NOVA_ENDPOINT.concat(tenants.getList().get(0).getId()));
+			novaClient.token(access.getToken().getId());
 			//novaClient.enableLogging(Logger.getLogger("nova"), 100 * 1024);
 			//create a new keypair
 			//KeyPair keyPair = novaClient.execute(KeyPairsExtension.createKeyPair("mykeypair"));

--- a/openstack-examples/src/main/java/org/openstack/examples/compute/NovaListFlavors.java
+++ b/openstack-examples/src/main/java/org/openstack/examples/compute/NovaListFlavors.java
@@ -50,7 +50,8 @@ public class NovaListFlavors {
 			access = keystone.execute(new Authenticate(authentication));
 			
 			//NovaClient novaClient = new NovaClient(KeystoneUtils.findEndpointURL(access.getServiceCatalog(), "compute", null, "public"), access.getToken().getId());
-			NovaClient novaClient = new NovaClient(ExamplesConfiguration.NOVA_ENDPOINT.concat(tenants.getList().get(0).getId()), access.getToken().getId());
+			NovaClient novaClient = new NovaClient(ExamplesConfiguration.NOVA_ENDPOINT.concat(tenants.getList().get(0).getId()));
+			novaClient.token(access.getToken().getId());
 			//novaClient.enableLogging(Logger.getLogger("nova"), 100 * 1024);
 			
 			Flavors flavors = novaClient.execute(FlavorsCore.listFlavors(true));

--- a/openstack-examples/src/main/java/org/openstack/examples/compute/NovaListImages.java
+++ b/openstack-examples/src/main/java/org/openstack/examples/compute/NovaListImages.java
@@ -51,7 +51,8 @@ public class NovaListImages {
 			access = keystone.execute(new Authenticate(authentication));
 			
 			//NovaClient novaClient = new NovaClient(KeystoneUtils.findEndpointURL(access.getServiceCatalog(), "compute", null, "public"), access.getToken().getId());
-			NovaClient novaClient = new NovaClient(ExamplesConfiguration.NOVA_ENDPOINT.concat(tenants.getList().get(0).getId()), access.getToken().getId());
+			NovaClient novaClient = new NovaClient(ExamplesConfiguration.NOVA_ENDPOINT.concat(tenants.getList().get(0).getId()));
+			novaClient.token(access.getToken().getId());
 			//novaClient.enableLogging(Logger.getLogger("nova"), 100 * 1024);
 			
 			Images images = novaClient.execute(ImagesCore.listImages(true));

--- a/openstack-examples/src/main/java/org/openstack/examples/compute/NovaListServers.java
+++ b/openstack-examples/src/main/java/org/openstack/examples/compute/NovaListServers.java
@@ -50,7 +50,8 @@ public class NovaListServers {
 			access = keystone.execute(new Authenticate(authentication));
 			
 			//NovaClient novaClient = new NovaClient(KeystoneUtils.findEndpointURL(access.getServiceCatalog(), "compute", null, "public"), access.getToken().getId());
-			NovaClient novaClient = new NovaClient(ExamplesConfiguration.NOVA_ENDPOINT.concat(tenants.getList().get(0).getId()), access.getToken().getId());
+			NovaClient novaClient = new NovaClient(ExamplesConfiguration.NOVA_ENDPOINT.concat(tenants.getList().get(0).getId()));
+			novaClient.token(access.getToken().getId());
 			//novaClient.enableLogging(Logger.getLogger("nova"), 100 * 1024);
 			
 			Servers servers = novaClient.execute(ServersCore.listServers(true));

--- a/openstack-examples/src/main/java/org/openstack/examples/glance/GlanceListImages.java
+++ b/openstack-examples/src/main/java/org/openstack/examples/glance/GlanceListImages.java
@@ -1,6 +1,5 @@
 package org.openstack.examples.glance;
 
-import org.openstack.connector.JaxRs20Connector;
 import org.openstack.examples.ExamplesConfiguration;
 import org.openstack.glance.GlanceClient;
 import org.openstack.glance.api.ListImages;
@@ -19,10 +18,8 @@ public class GlanceListImages {
 	 * @param args
 	 */
 	public static void main(String[] args) {
-		JaxRs20Connector connector = new JaxRs20Connector();
-
 		KeystoneClient keystone = new KeystoneClient(
-				ExamplesConfiguration.KEYSTONE_AUTH_URL, connector);
+				ExamplesConfiguration.KEYSTONE_AUTH_URL);
 
 		Access access = keystone.execute(Authenticate.withPasswordCredentials(
 				ExamplesConfiguration.KEYSTONE_USERNAME,
@@ -38,7 +35,8 @@ public class GlanceListImages {
 
 			GlanceClient client = new GlanceClient(
 					KeystoneUtils.findEndpointURL(access.getServiceCatalog(),
-							"image", null, "public"), connector);
+							"image", null, "public"));
+			client.token(access.getToken().getId());
 
 			Images images = client.execute(new ListImages(false));
 

--- a/quantum-client/src/main/java/org/openstack/quantum/client/QuantumClient.java
+++ b/quantum-client/src/main/java/org/openstack/quantum/client/QuantumClient.java
@@ -6,12 +6,12 @@ import org.openstack.base.client.OpenStackRequest;
 
 public class QuantumClient extends OpenStackClient {
 	
-	public QuantumClient(String endpoint, OpenStackClientConnector connector) {
-		super(endpoint, connector);
+	public QuantumClient(String endpoint) {
+		super(endpoint);
 	}
 	
-	public QuantumClient(String endpoint) {
-		this(endpoint, null);
+	public QuantumClient(String endpoint, OpenStackClientConnector connector) {
+		super(endpoint, connector);
 	}
 
 	public <R> R execute(QuantumCommand<R> command) {

--- a/swift-client/src/main/java/org/openstack/swift/SwiftClient.java
+++ b/swift-client/src/main/java/org/openstack/swift/SwiftClient.java
@@ -6,12 +6,12 @@ import org.openstack.base.client.OpenStackRequest;
 
 public class SwiftClient extends OpenStackClient {
 	
-	public SwiftClient(String endpoint, OpenStackClientConnector connector) {
-		super(endpoint, connector);
+	public SwiftClient(String endpoint) {
+		super(endpoint);
 	}
 	
-	public SwiftClient(String endpoint) {
-		super(endpoint, null);
+	public SwiftClient(String endpoint, OpenStackClientConnector connector) {
+		super(endpoint, connector);
 	}
 
 	public <R> R execute(SwiftCommand<R> command) {


### PR DESCRIPTION
This patch takes advantage of ServiceLoader to automatically select a
default connector (DEFAULT_CONNECTOR). It is still possible to specify
a custom connector at the moment of the creation of any OpenStackClient.

Signed-off-by: Federico Simoncelli fsimonce@redhat.com
