### PR TITLE
fix OS-EXT-IPS-MAC:mac_addr issue

### DIFF
--- a/nova-model/src/main/java/org/openstack/nova/model/Server.java
+++ b/nova-model/src/main/java/org/openstack/nova/model/Server.java
@@ -17,12 +17,22 @@ public class Server implements Serializable {
 		
 		public static final class Address implements Serializable {
 			
+			@JsonProperty("OS-EXT-IPS-MAC:mac_addr")
+			private String macAddr;
+
 			private String version;
 			
 			private String addr;
 			
 			@JsonProperty("OS-EXT-IPS:type")
 			private String type;
+
+                        /**
+                         * @return the macAddr
+                         */
+			public String getMacAddr() {
+				return macAddr;
+			}
 
 			/**
 			 * @return the version
@@ -66,7 +76,13 @@ public class Server implements Serializable {
 			public void setType(String type) {
 				this.type = type;
 			}
-			
+
+			/**
+			 * @param macAddr the mac addr to set
+			 */
+			public void setMacAddr(String macAddr) {
+				this.macAddr= macAddr;
+			}
 		}
 
 		private Map<String, List<Address>> addresses = new HashMap<String, List<Address>>();


### PR DESCRIPTION
the latest openstack add a extension attribute to server model, which
caused the NovaListServer example failed. see
https://blueprints.launchpad.net/nova/+spec/os-ext-ips-mac-api-extension
for details.
