### PR TITLE
Client connectors: support for multiple values for query parameter keys

### DIFF
--- a/openstack-client-connectors/jersey-connector/src/main/java/com/woorea/openstack/connector/JerseyConnector.java
+++ b/openstack-client-connectors/jersey-connector/src/main/java/com/woorea/openstack/connector/JerseyConnector.java
@@ -37,8 +37,10 @@ public class JerseyConnector implements OpenStackClientConnector {
 	@Override
 	public <T> T execute(OpenStackRequest<T> request) {
 		WebResource target = client.resource(request.endpoint()).path(request.path());
-		for(Map.Entry<String, Object> entry : request.queryParams().entrySet()) {
-			target = target.queryParam(entry.getKey(), String.valueOf(entry.getValue()));
+		for(Map.Entry<String, List<Object> > entry : request.queryParams().entrySet()) {
+			for (Object o : entry.getValue()) {
+				target = target.queryParam(entry.getKey(), String.valueOf(o));
+			}
 		}
 		target.addFilter(new LoggingFilter());
 		

--- a/openstack-client-connectors/jersey2-connector/src/main/java/com/woorea/openstack/connector/JaxRs20Connector.java
+++ b/openstack-client-connectors/jersey2-connector/src/main/java/com/woorea/openstack/connector/JaxRs20Connector.java
@@ -25,8 +25,10 @@ public class JaxRs20Connector implements OpenStackClientConnector {
 	public <T> OpenStackResponse request(OpenStackRequest<T> request) {
 		WebTarget target = client.target(request.endpoint()).path(request.path());
 
-		for(Map.Entry<String, Object> entry : request.queryParams().entrySet()) {
-			target = target.queryParam(entry.getKey(), entry.getValue());
+		for(Map.Entry<String, List<Object> > entry : request.queryParams().entrySet()) {
+			for (Object o : entry.getValue()) {
+				target = target.queryParam(entry.getKey(), o);
+			}
 		}
 
 		target.register(new LoggingFilter(Logger.getLogger("os"), 10000));

--- a/openstack-client-connectors/resteasy-connector/src/main/java/com/woorea/openstack/connector/RESTEasyConnector.java
+++ b/openstack-client-connectors/resteasy-connector/src/main/java/com/woorea/openstack/connector/RESTEasyConnector.java
@@ -68,8 +68,10 @@ public class RESTEasyConnector implements OpenStackClientConnector {
 		ClientRequest client = new ClientRequest(UriBuilder.fromUri(request.endpoint() + "/" + request.path()),
 				ClientRequest.getDefaultExecutor(), providerFactory);
 
-		for(Map.Entry<String, Object> entry : request.queryParams().entrySet()) {
-			client = client.queryParameter(entry.getKey(), String.valueOf(entry.getValue()));
+		for(Map.Entry<String, List<Object> > entry : request.queryParams().entrySet()) {
+			for (Object o : entry.getValue()) {
+				client = client.queryParameter(entry.getKey(), String.valueOf(o));
+			}
 		}
 
 		for (Entry<String, List<Object>> h : request.headers().entrySet()) {

--- a/openstack-client/src/main/java/com/woorea/openstack/base/client/OpenStackRequest.java
+++ b/openstack-client/src/main/java/com/woorea/openstack/base/client/OpenStackRequest.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.Map;
 
 public class OpenStackRequest<R> {
@@ -107,14 +108,22 @@ public class OpenStackRequest<R> {
 				+ entity + ", returnType=" + returnType + "]";
 	}
 
-	private Map<String, Object> queryParams = new LinkedHashMap<String, Object>();
+	private Map<String, List<Object> > queryParams = new LinkedHashMap<String, List<Object> >();
 
-	public Map<String, Object> queryParams() {
+	public Map<String, List<Object> > queryParams() {
 		return queryParams;
 	}
 
 	public OpenStackRequest<R> queryParam(String key, Object value) {
-		queryParams.put(key, value);
+		if (queryParams.containsKey(key)) {
+			List<Object> values = queryParams.get(key);
+			values.add(value);
+		} else {
+			List<Object> values = new ArrayList<Object>();
+			values.add(value);
+			queryParams.put(key, values);
+		}
+
 		return this;
     }
 	


### PR DESCRIPTION
Use Map<String, List<Object>> instead of Map<String, Object> and do not overwrite previous value for a key if a new value is given for the same key. The use of list preserves the order of values for a key, while the order of keys is not fixed. 

This e.g. allows the use of multiple Ceilometer query filters.
