### PR TITLE
Swift TempAuth and Copy commands along with an example

### DIFF
--- a/openstack-examples/src/main/java/org/openstack/examples/objectstore/SwiftCopyExample.java
+++ b/openstack-examples/src/main/java/org/openstack/examples/objectstore/SwiftCopyExample.java
@@ -1,0 +1,39 @@
+package org.openstack.examples.objectstore;
+
+import java.util.HashMap;
+import java.util.List;
+
+import javax.ws.rs.core.Response;
+
+import org.openstack.swift.SwiftClient;
+import org.openstack.swift.api.*;
+import org.openstack.swift.model.Object;
+
+/**
+ * Swift copy operation with TempAuth.
+ * The containers and source file need to exist.
+ *
+ * @author Robin Bramley
+ */
+public class SwiftCopyExample {
+    
+    public static void main( String[] args ) {
+        SwiftClient swiftClient = new SwiftClient("https://192.168.22.66:8443/auth/v1.0", null);
+        Response res = swiftClient.execute(new TempAuthenticate("test:tester", "testing"));
+        
+        String storageUrl = res.getHeaderString(TempAuthenticate.RES_HEADER_STORAGE_URL);
+        String token = res.getHeaderString(TempAuthenticate.RES_HEADER_AUTH_TOKEN);
+        System.out.println("Token: " + token);
+        
+        swiftClient = new SwiftClient(storageUrl, token);
+        
+        swiftClient.execute(new CopyObject("container1","robin_monochrome.jpg","backup","rb-mono.jpg", "image/jpeg"));
+        
+        List<Object> objs = swiftClient.execute(new ListObjects("backup", new HashMap<String, String>() {{
+            put("path", "");
+        }}));
+        for(Object obj : objs) {
+            System.out.println(obj.getName() + " - " + obj.getContentType());
+        }
+    }
+}

--- a/swift-client/src/main/java/org/openstack/swift/api/CopyObject.java
+++ b/swift-client/src/main/java/org/openstack/swift/api/CopyObject.java
@@ -1,0 +1,57 @@
+package org.openstack.swift.api;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.openstack.swift.SwiftCommand;
+
+/**
+ * Copy an object.
+ * "do a PUT to the new object (the target) location, but add the 'X-Copy-From' header to designate the source of the data"
+ * 
+ * @author Robin Bramley
+ */
+public class CopyObject implements SwiftCommand<Response>{
+
+    private static final String DELIMITER = "/";
+
+    private static final String REQ_HEADER_COPY_FROM = "X-Copy-From";
+
+    private String sourceContainerName;
+    
+	private String sourceObjectName;
+
+	private String destContainerName;
+	
+	private String destObjectName;
+    
+    private String mimeType;
+
+	public CopyObject(String sourceContainerName, String sourceObjectName, String destContainerName, String destObjectName, String mimeType) {
+		this.sourceContainerName = sourceContainerName;
+        this.sourceObjectName = sourceObjectName;
+        this.destContainerName = destContainerName;
+        this.destObjectName = destObjectName;
+        this.mimeType = mimeType;
+	}
+	
+	@Override
+	public Response execute(WebTarget target) {
+        // set up the value for the X-Copy-From header
+        StringBuilder sb = new StringBuilder(2
+                                             + sourceContainerName.length()
+                                             + sourceObjectName.length())
+            .append(DELIMITER).append(sourceContainerName)
+            .append(DELIMITER).append(sourceObjectName);
+        String source = sb.toString();
+        
+		Invocation.Builder invocationBuilder = target.path(destContainerName).path(destObjectName).request();
+        
+        invocationBuilder.header(REQ_HEADER_COPY_FROM, source);
+
+		return invocationBuilder.put(Entity.entity("", mimeType));
+	}
+
+}

--- a/swift-client/src/main/java/org/openstack/swift/api/TempAuthenticate.java
+++ b/swift-client/src/main/java/org/openstack/swift/api/TempAuthenticate.java
@@ -1,0 +1,41 @@
+package org.openstack.swift.api;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.openstack.swift.SwiftCommand;
+
+/**
+ * Perform TempAuth authentication
+ * 
+ * @author Robin Bramley
+ */
+public class TempAuthenticate implements SwiftCommand<Response>{
+
+    private static final String REQ_HEADER_STORAGE_USER = "X-Storage-User";
+    private static final String REQ_HEADER_STORAGE_PASS = "X-Storage-Pass";
+    public static final String RES_HEADER_STORAGE_URL = "X-Storage-Url";
+    public static final String RES_HEADER_AUTH_TOKEN = "X-Auth-Token";
+    
+    private String storageUser;
+    
+	private String storagePass;
+
+	public TempAuthenticate(String storageUser, String storagePass) {
+		this.storageUser = storageUser;
+        this.storagePass = storagePass;
+	}
+	
+	@Override
+	public Response execute(WebTarget target) {
+		Invocation.Builder invocationBuilder = target.request();
+        
+        invocationBuilder.header(REQ_HEADER_STORAGE_USER, storageUser);
+        invocationBuilder.header(REQ_HEADER_STORAGE_PASS, storagePass);
+
+		return invocationBuilder.get();
+	}
+
+}


### PR DESCRIPTION
Ability to use server-side object copies plus added TempAuth to make it available for non-Keystone environments.
