### PR TITLE
Add volume attachment list and show commands, fix detach command

### DIFF
--- a/nova-client/src/main/java/com/woorea/openstack/nova/api/ServersResource.java
+++ b/nova-client/src/main/java/com/woorea/openstack/nova/api/ServersResource.java
@@ -33,6 +33,7 @@ import com.woorea.openstack.nova.model.ServerAction.VncConsole;
 import com.woorea.openstack.nova.model.ServerForCreate;
 import com.woorea.openstack.nova.model.Servers;
 import com.woorea.openstack.nova.model.VolumeAttachment;
+import com.woorea.openstack.nova.model.VolumeAttachments;
 
 public class ServersResource {
 	
@@ -429,12 +430,24 @@ public class ServersResource {
 	
 	public class DetachVolume extends OpenStackRequest<Void> {
 		
-		private String serverId;
-		
-		private String volumeId;
-		
 		public DetachVolume(String serverId, String volumeId) {
-			super(CLIENT, HttpMethod.DELETE, new StringBuilder("/servers/").append(serverId).append("/os-volume_attachments").append(volumeId), null, Void.class);
+			super(CLIENT, HttpMethod.DELETE, new StringBuilder("/servers/").append(serverId).append("/os-volume_attachments/").append(volumeId), null, Void.class);
+		}
+
+	}
+	
+	public  class ListVolumeAttachments extends OpenStackRequest<VolumeAttachments> {
+		
+		public ListVolumeAttachments(String serverId) {
+			super(CLIENT, HttpMethod.GET, new StringBuilder("/servers/").append(serverId).append("/os-volume_attachments"), null, VolumeAttachments.class);
+		}
+
+	}
+	
+	public  class ShowVolumeAttachment extends OpenStackRequest<VolumeAttachment> {
+		
+		public ShowVolumeAttachment(String serverId, String volumeAttachmentId) {
+			super(CLIENT, HttpMethod.GET, new StringBuilder("/servers/").append(serverId).append("/os-volume_attachments/").append(volumeAttachmentId), null, VolumeAttachment.class);
 		}
 
 	}
@@ -448,6 +461,14 @@ public class ServersResource {
 	
 	public DetachVolume detachVolume(String serverId, String volumeId) {
 		return new DetachVolume(serverId, volumeId);
+	}
+	
+	public ListVolumeAttachments listVolumeAttachments(String serverId) {
+		return new ListVolumeAttachments(serverId);
+	}
+	
+	public ShowVolumeAttachment showVolumeAttachment(String serverId, String volumeAttachmentId) {
+		return new ShowVolumeAttachment(serverId, volumeAttachmentId);
 	}
 	
 }

--- a/nova-model/src/main/java/com/woorea/openstack/nova/model/VolumeAttachments.java
+++ b/nova-model/src/main/java/com/woorea/openstack/nova/model/VolumeAttachments.java
@@ -1,0 +1,34 @@
+package com.woorea.openstack.nova.model;
+
+import java.io.Serializable;
+import java.util.Iterator;
+import java.util.List;
+
+import org.codehaus.jackson.annotate.JsonProperty;
+
+public class VolumeAttachments implements Iterable<VolumeAttachment>, Serializable {
+
+	@JsonProperty("volumeAttachments")
+	private List<VolumeAttachment> list;
+
+	/**
+	 * @return the list
+	 */
+	public List<VolumeAttachment> getList() {
+		return list;
+	}
+
+	@Override
+	public Iterator<VolumeAttachment> iterator() {
+		return list.iterator();
+	}
+	
+	/* (non-Javadoc)
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		return "VolumeAttachments [list=" + list + "]";
+	}
+
+}


### PR DESCRIPTION
Fix volume detach command: missing trailing slash in "os-volume_attachments"
Add volume attachment list and show commands
-listVolumeAttachments
-showVolumeAttachment

Note that I'm not sure about Woorea naming conventions. Maybe both operations should be called "show" ?
