### PR TITLE
Disable the FAIL_ON_UNKNOWN_PROPERTIES feature on Jersey Connector ObjectMappers

### DIFF
--- a/openstack-client-connectors/jersey-connector/src/main/java/com/woorea/openstack/connector/JerseyConnector.java
+++ b/openstack-client-connectors/jersey-connector/src/main/java/com/woorea/openstack/connector/JerseyConnector.java
@@ -83,12 +83,14 @@ public class JerseyConnector implements OpenStackClientConnector {
 			DEFAULT_MAPPER.setSerializationInclusion(Inclusion.NON_NULL);
 			DEFAULT_MAPPER.enable(SerializationConfig.Feature.INDENT_OUTPUT);
 			DEFAULT_MAPPER.enable(DeserializationConfig.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+			DEFAULT_MAPPER.disable(DeserializationConfig.Feature.FAIL_ON_UNKNOWN_PROPERTIES);
 			WRAPPED_MAPPER = new ObjectMapper();
 			WRAPPED_MAPPER.setSerializationInclusion(Inclusion.NON_NULL);
 			WRAPPED_MAPPER.enable(SerializationConfig.Feature.INDENT_OUTPUT);
 			WRAPPED_MAPPER.enable(SerializationConfig.Feature.WRAP_ROOT_VALUE);
 			WRAPPED_MAPPER.enable(DeserializationConfig.Feature.UNWRAP_ROOT_VALUE);
 			WRAPPED_MAPPER.enable(DeserializationConfig.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+			WRAPPED_MAPPER.disable(DeserializationConfig.Feature.FAIL_ON_UNKNOWN_PROPERTIES);
 		}
 		
 		@Override


### PR DESCRIPTION
This prevents deserialization from failing for unknown fields.
