### PR TITLE
Modified ServersResource's StopServer Constructor

### DIFF
--- a/nova-client/src/main/java/com/woorea/openstack/nova/api/ServersResource.java
+++ b/nova-client/src/main/java/com/woorea/openstack/nova/api/ServersResource.java
@@ -225,16 +225,10 @@ public class ServersResource {
 		private Stop action;
 
 		private String id;
-		
-		public StopServer(String id) {
-			this.id = id;
-			this.action = new Stop();
-			
-			method(HttpMethod.POST);
-		    path("/servers/").path(id).path("/action");
-		    header("Accept", "application/json");
-		    json(action);
-		}
+
+        public StopServer(String id) {
+            super(CLIENT, HttpMethod.POST, new StringBuilder("/servers/").append(id).append("/action"), Entity.json(new Stop()), Void.class);
+        }
 
 	}
 	


### PR DESCRIPTION
Previous constructor occurs "NullPointerException" because it didn't handle endpoint and clinent initialize. So I altered it with super(...) and nova-client's stop() api works just fine. I belieave StartServer's constructor have same issue(Not changed yet).
