### PR TITLE
Bug in the model

### DIFF
--- a/nova-model/src/main/java/com/woorea/openstack/nova/model/HostAggregate.java
+++ b/nova-model/src/main/java/com/woorea/openstack/nova/model/HostAggregate.java
@@ -28,7 +28,7 @@ public class HostAggregate implements Serializable {
 	
 	private Boolean deleted;
 	
-	private List<Host> hosts;
+	private List<String> hosts;
 	
 	private Map<String, String> metadata;
 
@@ -84,7 +84,7 @@ public class HostAggregate implements Serializable {
 	/**
 	 * @return the hosts
 	 */
-	public List<Host> getHosts() {
+	public List<String> getHosts() {
 		return hosts;
 	}
 


### PR DESCRIPTION
Openstack api call returns host as a list of Strings instead of a complete object.
