### PR TITLE
Upgrade jackson library from 1.9.4 to 1.9.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
 		<dependency>
 			<groupId>org.codehaus.jackson</groupId>
 			<artifactId>jackson-mapper-asl</artifactId>
-			<version>1.9.4</version>
+			<version>1.9.13</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
## The ipVersion enum of Subnet is not supported by Jackson mapper library 1.9.4. 

org.codehaus.jackson.map.JsonMappingException: Parameter #0 type for factory method ([method valueOf, annotations: {interface org.codehaus.jackson.annotate.JsonCreator=@org.codehaus.jackson.annotate.JsonCreator()}]) not suitable, must be java.lang.String
