### PR TITLE
Issue #101 Openstack-java-sdk 3.2.2-SNAPSHOT incompatible with OpenStack 2013.2 (Havana)

### DIFF
--- a/nova-model/src/main/java/com/woorea/openstack/nova/model/Server.java
+++ b/nova-model/src/main/java/com/woorea/openstack/nova/model/Server.java
@@ -12,7 +12,6 @@ import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.map.annotate.JsonRootName;
 
 @JsonRootName("server")
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class Server implements Serializable {
 	
 	public static final class Addresses implements Serializable {


### PR DESCRIPTION
Added new fields in Server.class for compatibility with OpenStack 2013.2 Havana version.
