### PR TITLE
Fix a typo of @JsonRootName in HostAggregate.java.

### DIFF
--- a/nova-model/src/main/java/com/woorea/openstack/nova/model/HostAggregate.java
+++ b/nova-model/src/main/java/com/woorea/openstack/nova/model/HostAggregate.java
@@ -7,7 +7,7 @@ import java.util.Map;
 import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.map.annotate.JsonRootName;
 
-@JsonRootName("aggreagate")
+@JsonRootName("aggregate")
 public class HostAggregate implements Serializable {
 	
 	private String id;


### PR DESCRIPTION
Hello, 

I found a small typo in HostAggregate.java under nova-model.
Thetypo causes deserialize errors in jackson layer for HostAggregate related responses,
and this patch fixes the issue.

Regards,
Masanori
