### PR TITLE
resteasy: catch IllegalStateException on InputStream close

### DIFF
--- a/openstack-client-connectors/resteasy-connector/src/main/java/com/woorea/openstack/connector/RESTEasyInputStream.java
+++ b/openstack-client-connectors/resteasy-connector/src/main/java/com/woorea/openstack/connector/RESTEasyInputStream.java
@@ -28,7 +28,9 @@ public class RESTEasyInputStream extends FilterInputStream {
 		try {
 			super.close();
 		} catch (SocketException e) {
-			// We expect this to fail because the socket is closed
+			// We expect this exception because the socket is closed
+		} catch (IllegalStateException e) {
+			// We expect this exception because the socket is closed (httpclient 4.2)
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Federico Simoncelli fsimonce@redhat.com
