### PR TITLE
Fix deserialization errors on router operations

### DIFF
--- a/quantum-model/src/main/java/com/woorea/openstack/quantum/model/GatewayInfo.java
+++ b/quantum-model/src/main/java/com/woorea/openstack/quantum/model/GatewayInfo.java
@@ -1,0 +1,24 @@
+package com.woorea.openstack.quantum.model;
+
+import java.util.List;
+import java.io.Serializable;
+
+import org.codehaus.jackson.annotate.JsonProperty;
+
+public class GatewayInfo implements Serializable {
+
+	@JsonProperty("network_id")
+	private String networkId;
+
+	public String getNetworkId() {
+		return networkId;
+	}
+
+	public void setNetworkId(String id) {
+		this.networkId = id;
+	}
+
+	@Override public String toString() {
+		return "[networkId=" + networkId + "]";
+	}
+}

--- a/quantum-model/src/main/java/com/woorea/openstack/quantum/model/HostRoute.java
+++ b/quantum-model/src/main/java/com/woorea/openstack/quantum/model/HostRoute.java
@@ -1,0 +1,27 @@
+package com.woorea.openstack.quantum.model;
+
+import java.io.Serializable;
+
+public class HostRoute implements Serializable {
+
+	private String destination;
+	private String nexthop;
+
+	public String getDestination() {
+		return destination;
+	}
+	public void setDestination(String destination) {
+		this.destination = destination;
+	}
+
+	public String getNexthop() {
+		return nexthop;
+	}
+	public void setNexthop(String nexthop) {
+		this.nexthop = nexthop;
+	}
+
+	@Override public String toString() {
+		return "[destination=" + destination + ", nexthop=" + nexthop + "]";
+	}
+}

--- a/quantum-model/src/main/java/com/woorea/openstack/quantum/model/Router.java
+++ b/quantum-model/src/main/java/com/woorea/openstack/quantum/model/Router.java
@@ -1,40 +1,46 @@
 package com.woorea.openstack.quantum.model;
 
 import java.util.List;
+import java.io.Serializable;
 
 import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.map.annotate.JsonRootName;
-@JsonRootName("router")
-public class Router {
 
-	/**
-	 * @param args
-	 */
+@JsonRootName("router")
+public class Router implements Serializable {
+
 	@JsonProperty("status")
-	String status;
+	private String status;
+
 	@JsonProperty("external_gateway_info")
-	String externalGatewayInfo;
+	private GatewayInfo externalGatewayInfo;
+
 	@JsonProperty("name")
-	String name;
+	private String name;
+
 	@JsonProperty("admin_state_up")
-	String admin_state_up;
+	private String admin_state_up;
+
 	@JsonProperty("tenant_id")
-	String tenantId;
+	private String tenantId;
+
 	@JsonProperty("id")
-	String id;
+	private String id;
+
 	@JsonProperty("routes")
-	private List<String> routers;
+	private List<HostRoute> routes;
+
 	public String getName() {
 		return name;
 	}
 	public void setName(String name) {
 		this.name = name;
 	}
-	public List<String> getRouters() {
-		return routers;
+	public List<HostRoute> getRoutes() {
+		return routes;
 	}
-	public void setRouters(List<String> routers) {
-		this.routers = routers;
+	public void setRoutes(List<HostRoute> routes) {
+		this.routes = routes;
 	}
 	public String getAdmin_state_up() {
 		return admin_state_up;
@@ -48,10 +54,10 @@ public class Router {
 	public void setStatus(String status) {
 		this.status = status;
 	}
-	public String getExternalGatewayInfo() {
+	public GatewayInfo getExternalGatewayInfo() {
 		return externalGatewayInfo;
 	}
-	public void setExternalGatewayInfo(String externalGatewayInfo) {
+	public void setExternalGatewayInfo(GatewayInfo externalGatewayInfo) {
 		this.externalGatewayInfo = externalGatewayInfo;
 	}
 	public String getTenantId() {

--- a/quantum-model/src/main/java/com/woorea/openstack/quantum/model/RouterForCreate.java
+++ b/quantum-model/src/main/java/com/woorea/openstack/quantum/model/RouterForCreate.java
@@ -1,35 +1,45 @@
 package com.woorea.openstack.quantum.model;
 
 import java.util.List;
+import java.io.Serializable;
 
 import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.map.annotate.JsonRootName;
+
 @JsonRootName("router")
-public class RouterForCreate {
+public class RouterForCreate implements Serializable {
+
 	@JsonProperty("name")
-	String name;
-	private List<String> routers;
+	private String name;
+
+	private List<HostRoute> routes;
+
 	@JsonProperty("admin_state_up")
-	String admin_state_up;
+	private String admin_state_up;
+
 	@JsonProperty("status")
-	String status;
+	private String status;
+
 	@JsonProperty("external_gateway_info")
-	String externalGatewayInfo;
+	private GatewayInfo externalGatewayInfo;
+
 	@JsonProperty("tenant_id")
-	String tenantId;
+	private String tenantId;
+
 	@JsonProperty("id")
-	String id;
+	private String id;
+
 	public String getName() {
 		return name;
 	}
 	public void setName(String name) {
 		this.name = name;
 	}
-	public List<String> getRouters() {
-		return routers;
+	public List<HostRoute> getRoutes() {
+		return routes;
 	}
-	public void setRouters(List<String> routers) {
-		this.routers = routers;
+	public void setRoutes(List<HostRoute> routes) {
+		this.routes = routes;
 	}
 	public String getAdmin_state_up() {
 		return admin_state_up;
@@ -43,10 +53,10 @@ public class RouterForCreate {
 	public void setStatus(String status) {
 		this.status = status;
 	}
-	public String getExternalGatewayInfo() {
+	public GatewayInfo getExternalGatewayInfo() {
 		return externalGatewayInfo;
 	}
-	public void setExternalGatewayInfo(String externalGatewayInfo) {
+	public void setExternalGatewayInfo(GatewayInfo externalGatewayInfo) {
 		this.externalGatewayInfo = externalGatewayInfo;
 	}
 	public String getTenantId() {


### PR DESCRIPTION
Hi,

I found that now we get deserialization errors on operations of routers
because of several problems.

First of all, 'routers' is 'routes' which is a list of static routes.
Also, a static route is a JSON object with two keys 'destination' and
'nexthop'. Thus, we need a class to map it.

The other is handling of 'external_gateway_info'. Now, it's defined as
a String, but actually it's JSON object which has structure to be mapped
to a class.

This patch resolves the issues above.
I tested againt grizzly and havana.

Please note that I made the additional classes as separated independent
.java files because they can be used from other classes such as 
RouterForCreate and Subnet etc. As for the issue on Subnet, I'm preparing
another patch.

Best regards,
Masanori
