### PR TITLE
Adding field and model object for the 'networks' field on server create

### DIFF
--- a/nova-model/src/main/java/com/woorea/openstack/nova/model/NetworkForCreate.java
+++ b/nova-model/src/main/java/com/woorea/openstack/nova/model/NetworkForCreate.java
@@ -1,0 +1,29 @@
+package com.woorea.openstack.nova.model;
+
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.map.annotate.JsonRootName;
+
+public class NetworkForCreate {
+
+	@JsonProperty("uuid")
+	private String id;
+	@JsonProperty("fixed_ip")
+	private String fixedIp;
+
+	public String getId() {
+		return id;
+	}
+
+	public String getFixedIp() {
+		return fixedIp;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public void setFixedIp(String fixedIp) {
+		this.fixedIp = fixedIp;
+	}
+
+}

--- a/nova-model/src/main/java/com/woorea/openstack/nova/model/ServerForCreate.java
+++ b/nova-model/src/main/java/com/woorea/openstack/nova/model/ServerForCreate.java
@@ -11,14 +11,14 @@ import org.codehaus.jackson.map.annotate.JsonRootName;
 
 @JsonRootName("server")
 public class ServerForCreate implements Serializable {
-	
+
 	public static final class SecurityGroup implements Serializable {
-		
+
 		private String name;
 
 		public SecurityGroup() {
 		}
-		
+
 		public SecurityGroup(String name) {
 			this.name = name;
 		}
@@ -31,116 +31,54 @@ public class ServerForCreate implements Serializable {
 		}
 
 		/**
-		 * @param name the name to set
+		 * @param name
+		 *          the name to set
 		 */
 		public void setName(String name) {
 			this.name = name;
 		}
-		
+
 	}
-	
-	public static final class Network implements Serializable { 
-		
-		private String uuid;
-		
-		private String fixed_ip;
-		
-		private String port;
 
-		public Network() {
-		}
-		
-		public Network(String uuid, String fixed_ip, String port) {
-			this.uuid = uuid;
-			this.fixed_ip = fixed_ip;
-			this.port = port;
-		}
-
-		/**
-		 * @return the network uuid
-		 */
-		public String getUuid() {
-			return uuid;
-		}
-
-		/**
-		 * @param uuid the network uuid to set
-		 */
-		public void setUuid(String uuid) {
-			this.uuid = uuid;
-		}
-
-		/**
-		 * @return the IP address to assign to the interface
-		 */
-		public String getFixed_ip() {
-			return fixed_ip;
-		}
-
-		/**
-		 * @param name the IP address to set
-		 */
-		public void setFixed_ip(String fixed_ip) {
-			this.fixed_ip = fixed_ip;
-		}
-
-		/**
-		 * @return the port uuid
-		 */
-		public String getPort() {
-			return port;
-		}
-
-		/**
-		 * @param port the port uuid to set
-		 */
-		public void setPort(String port) {
-			this.port = port;
-		}
-		
-	}
-	
 	private String name;
-	
+
 	private String adminPass;
-	
+
 	private String imageRef;
-	
+
 	private String flavorRef;
-	
+
 	private String accessIPv4;
-	
+
 	private String accessIPv6;
-	
-	@JsonProperty("min_count")
+
 	private Integer min;
-	
-	@JsonProperty("max_count")
+
 	private Integer max;
-	
+
 	private String diskConfig;
-	
+
 	@JsonProperty("key_name")
 	private String keyName;
-	
+
 	private List<PersonalityFile> personality = new ArrayList<PersonalityFile>();
-	
+
 	private Map<String, String> metadata = new HashMap<String, String>();
-	
+
 	@JsonProperty("security_groups")
 	private List<SecurityGroup> securityGroups;
-	
-	@JsonProperty("networks")
-	private List<Network> networks;
-	
+
 	@JsonProperty("user_data")
 	private String userData;
-	
+
 	@JsonProperty("availability_zone")
 	private String availabilityZone;
 
 	@JsonProperty("config_drive")
 	private boolean configDrive;
+
+	@JsonProperty("networks")
+	private List<NetworkForCreate> networks = new ArrayList<NetworkForCreate>();
 
 	/**
 	 * @return the name
@@ -150,7 +88,8 @@ public class ServerForCreate implements Serializable {
 	}
 
 	/**
-	 * @param name the name to set
+	 * @param name
+	 *          the name to set
 	 */
 	public void setName(String name) {
 		this.name = name;
@@ -164,7 +103,8 @@ public class ServerForCreate implements Serializable {
 	}
 
 	/**
-	 * @param adminPass the adminPass to set
+	 * @param adminPass
+	 *          the adminPass to set
 	 */
 	public void setAdminPass(String adminPass) {
 		this.adminPass = adminPass;
@@ -178,7 +118,8 @@ public class ServerForCreate implements Serializable {
 	}
 
 	/**
-	 * @param imageRef the imageRef to set
+	 * @param imageRef
+	 *          the imageRef to set
 	 */
 	public void setImageRef(String imageRef) {
 		this.imageRef = imageRef;
@@ -192,7 +133,8 @@ public class ServerForCreate implements Serializable {
 	}
 
 	/**
-	 * @param flavorRef the flavorRef to set
+	 * @param flavorRef
+	 *          the flavorRef to set
 	 */
 	public void setFlavorRef(String flavorRef) {
 		this.flavorRef = flavorRef;
@@ -206,7 +148,8 @@ public class ServerForCreate implements Serializable {
 	}
 
 	/**
-	 * @param accessIPv4 the accessIPv4 to set
+	 * @param accessIPv4
+	 *          the accessIPv4 to set
 	 */
 	public void setAccessIPv4(String accessIPv4) {
 		this.accessIPv4 = accessIPv4;
@@ -220,7 +163,8 @@ public class ServerForCreate implements Serializable {
 	}
 
 	/**
-	 * @param accessIPv6 the accessIPv6 to set
+	 * @param accessIPv6
+	 *          the accessIPv6 to set
 	 */
 	public void setAccessIPv6(String accessIPv6) {
 		this.accessIPv6 = accessIPv6;
@@ -234,7 +178,8 @@ public class ServerForCreate implements Serializable {
 	}
 
 	/**
-	 * @param min the min to set
+	 * @param min
+	 *          the min to set
 	 */
 	public void setMin(Integer min) {
 		this.min = min;
@@ -248,7 +193,8 @@ public class ServerForCreate implements Serializable {
 	}
 
 	/**
-	 * @param max the max to set
+	 * @param max
+	 *          the max to set
 	 */
 	public void setMax(Integer max) {
 		this.max = max;
@@ -262,7 +208,8 @@ public class ServerForCreate implements Serializable {
 	}
 
 	/**
-	 * @param diskConfig the diskConfig to set
+	 * @param diskConfig
+	 *          the diskConfig to set
 	 */
 	public void setDiskConfig(String diskConfig) {
 		this.diskConfig = diskConfig;
@@ -276,7 +223,8 @@ public class ServerForCreate implements Serializable {
 	}
 
 	/**
-	 * @param keyName the keyName to set
+	 * @param keyName
+	 *          the keyName to set
 	 */
 	public void setKeyName(String keyName) {
 		this.keyName = keyName;
@@ -290,7 +238,8 @@ public class ServerForCreate implements Serializable {
 	}
 
 	/**
-	 * @param personality the personality to set
+	 * @param personality
+	 *          the personality to set
 	 */
 	public void setPersonality(List<PersonalityFile> personality) {
 		this.personality = personality;
@@ -304,7 +253,8 @@ public class ServerForCreate implements Serializable {
 	}
 
 	/**
-	 * @param metadata the metadata to set
+	 * @param metadata
+	 *          the metadata to set
 	 */
 	public void setMetadata(Map<String, String> metadata) {
 		this.metadata = metadata;
@@ -314,22 +264,12 @@ public class ServerForCreate implements Serializable {
 	 * @return the securityGroups
 	 */
 	public List<SecurityGroup> getSecurityGroups() {
-		if(securityGroups == null) {
+		if (securityGroups == null) {
 			securityGroups = new ArrayList<SecurityGroup>();
 		}
 		return securityGroups;
 	}
 
-	/**
-	 * @return the networks
-	 */
-	public List<Network> getNetworks() {
-		if(networks == null) {
-			networks = new ArrayList<Network>();
-		}
-		return networks;
-	}
-	
 	/**
 	 * @return the userData
 	 */
@@ -338,7 +278,8 @@ public class ServerForCreate implements Serializable {
 	}
 
 	/**
-	 * @param userData the userData to set
+	 * @param userData
+	 *          the userData to set
 	 */
 	public void setUserData(String userData) {
 		this.userData = userData;
@@ -352,7 +293,8 @@ public class ServerForCreate implements Serializable {
 	}
 
 	/**
-	 * @param availabilityZone the availabilityZone to set
+	 * @param availabilityZone
+	 *          the availabilityZone to set
 	 */
 	public void setAvailabilityZone(String availabilityZone) {
 		this.availabilityZone = availabilityZone;
@@ -365,4 +307,20 @@ public class ServerForCreate implements Serializable {
 	public void setConfigDrive(boolean configDrive) {
 		this.configDrive = configDrive;
 	}
+
+	public List<NetworkForCreate> getNetworks() {
+		return networks;
+	}
+
+	public void setNetworks(List<NetworkForCreate> networks) {
+		this.networks = networks;
+	}
+
+	public void addNetworks(String id, String fixedIp) {
+		NetworkForCreate net = new NetworkForCreate();
+		net.setId(id);
+		net.setFixedIp(fixedIp);
+		this.networks.add(net);
+	}
+
 }


### PR DESCRIPTION
I noticed that the networks field was not created when Jackson created the JSON for the ServerForCreate object. I added a new class called NetworkForCreate to hold the basics (network uuid and fixed_ip) and added a new field on the ServerForCreate object. I was able to successfully create servers with this change on my local Grizzly OpenStack cluster.
