### PR TITLE
Allow operations on /os-availability-zone. (nova availability-zone-list equivalent)

### DIFF
--- a/nova-client/src/main/java/com/woorea/openstack/nova/Nova.java
+++ b/nova-client/src/main/java/com/woorea/openstack/nova/Nova.java
@@ -15,6 +15,7 @@ import com.woorea.openstack.nova.api.extensions.SecurityGroupsExtension;
 import com.woorea.openstack.nova.api.extensions.SnapshotsExtension;
 import com.woorea.openstack.nova.api.extensions.VolumesExtension;
 import com.woorea.openstack.nova.api.extensions.HostsExtension;
+import com.woorea.openstack.nova.api.extensions.AvailabilityZoneInfoExtension;
 
 public class Nova extends OpenStackClient {
 	
@@ -42,6 +43,8 @@ public class Nova extends OpenStackClient {
 	
 	private final HostsExtension HOSTS;
 
+	private final AvailabilityZoneInfoExtension AVAILABILITYZONE;
+
 	public Nova(String endpoint, OpenStackClientConnector connector) {
 		super(endpoint, connector);
 		EXTENSIONS = new ExtensionsResource(this);
@@ -56,6 +59,7 @@ public class Nova extends OpenStackClient {
 		AGGREGATES = new AggregatesExtension(this);
 		QUOTA_SETS = new QuotaSetsResource(this);
 		HOSTS = new HostsExtension(this);
+		AVAILABILITYZONE = new AvailabilityZoneInfoExtension(this);
 	}
 	
 	public Nova(String endpoint) {
@@ -108,6 +112,10 @@ public class Nova extends OpenStackClient {
 
 	public HostsExtension hosts() {
 		return HOSTS;
+	}
+
+	public AvailabilityZoneInfoExtension availabilityZoneInfo() {
+		return AVAILABILITYZONE;
 	}
 
 }

--- a/nova-client/src/main/java/com/woorea/openstack/nova/api/extensions/AvailabilityZoneInfoExtension.java
+++ b/nova-client/src/main/java/com/woorea/openstack/nova/api/extensions/AvailabilityZoneInfoExtension.java
@@ -1,0 +1,27 @@
+package com.woorea.openstack.nova.api.extensions;
+import com.woorea.openstack.base.client.Entity;
+import com.woorea.openstack.base.client.HttpMethod;
+import com.woorea.openstack.base.client.OpenStackClient;
+import com.woorea.openstack.base.client.OpenStackRequest;
+import com.woorea.openstack.nova.model.AvailabilityZoneInfo;
+
+public class AvailabilityZoneInfoExtension {
+
+	private final OpenStackClient CLIENT;
+	
+	public AvailabilityZoneInfoExtension(OpenStackClient client) {
+		CLIENT = client;
+	}
+
+	public Show show(boolean isDetail) {
+		return new Show(isDetail);
+	}
+
+	public class Show extends OpenStackRequest<AvailabilityZoneInfo> {
+
+		public Show(boolean isDetail) {
+			super(CLIENT, HttpMethod.GET,
+				  new StringBuffer(isDetail ? "/os-availability-zone/detail" : "os-availability-zone"), null, AvailabilityZoneInfo.class);
+		}
+	}
+}

--- a/nova-model/src/main/java/com/woorea/openstack/nova/model/AvailabilityZoneInfo.java
+++ b/nova-model/src/main/java/com/woorea/openstack/nova/model/AvailabilityZoneInfo.java
@@ -1,0 +1,86 @@
+package com.woorea.openstack.nova.model;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.map.annotate.JsonRootName;
+
+public class AvailabilityZoneInfo implements Serializable {
+
+	private static final class ZoneState {
+		@JsonProperty("available")
+		private boolean available;
+
+		public boolean getAvailable() {
+			return available;
+		}
+		@Override
+		public String toString() {
+			return " available =[" + available + "]";
+		}
+
+	}
+
+	private static final class ZoneServiceInfo {
+		@JsonProperty("updated_at")
+		private String updatedAt; 
+		private boolean active;
+		private boolean available;
+
+		public String getUpdatedAt() {
+			return updatedAt;
+		}
+
+		public boolean getActive() {
+			return active;
+		}
+		public boolean getAvailable() {
+			return available;
+		}
+
+		@Override
+		public String toString() {
+			return "updatedAt=" + updatedAt + ", active=" + active
+				+ ", available=" + available;
+		}
+	}
+
+	private static final class ZoneInfo {
+		private String zoneName;
+		private Map<String, Map<String, ZoneServiceInfo>> hosts;
+		private ZoneState zoneState;
+
+		public String getZoneName() {
+			return zoneName;
+		}
+		public Map<String, Map<String, ZoneServiceInfo>> getHosts() {
+			return hosts;
+		}
+		public ZoneState getZoneState() {
+			return zoneState;
+		}
+
+		@Override
+		public String toString() {
+			return "zoneName=" + zoneName + ", hosts=" + hosts
+				+ ", zoneState=" + zoneState + "]";
+		}
+	}
+	
+	private List<ZoneInfo> availabilityZoneInfo;
+
+	public List<ZoneInfo> getAvailabilityZoneInfo() {
+		return availabilityZoneInfo;
+	}
+
+	/* (non-Javadoc)
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		//FIXME(thatsdone): ipmlement!
+		return "AvailabilityZoneInfo=[" + availabilityZoneInfo + "]";
+	}
+}


### PR DESCRIPTION
Hi,
This patch adds 'nova availability-zone-list' equivalent feature and resolves #148 raised by venkatnsrinivasan.

Thanks in advance,
Masanori
