### PR TITLE
Deserialize an empty json string to a null object

### DIFF
--- a/openstack-client-connectors/jersey-connector/src/main/java/com/woorea/openstack/connector/JerseyConnector.java
+++ b/openstack-client-connectors/jersey-connector/src/main/java/com/woorea/openstack/connector/JerseyConnector.java
@@ -84,6 +84,8 @@ public class JerseyConnector implements OpenStackClientConnector {
 			DEFAULT_MAPPER.enable(SerializationConfig.Feature.INDENT_OUTPUT);
 			DEFAULT_MAPPER.enable(DeserializationConfig.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
 			DEFAULT_MAPPER.disable(DeserializationConfig.Feature.FAIL_ON_UNKNOWN_PROPERTIES);
+			DEFAULT_MAPPER.enable(DeserializationConfig.Feature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT);
+
 			WRAPPED_MAPPER = new ObjectMapper();
 			WRAPPED_MAPPER.setSerializationInclusion(Inclusion.NON_NULL);
 			WRAPPED_MAPPER.enable(SerializationConfig.Feature.INDENT_OUTPUT);
@@ -91,6 +93,7 @@ public class JerseyConnector implements OpenStackClientConnector {
 			WRAPPED_MAPPER.enable(DeserializationConfig.Feature.UNWRAP_ROOT_VALUE);
 			WRAPPED_MAPPER.enable(DeserializationConfig.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
 			WRAPPED_MAPPER.disable(DeserializationConfig.Feature.FAIL_ON_UNKNOWN_PROPERTIES);
+			WRAPPED_MAPPER.enable(DeserializationConfig.Feature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT);
 		}
 		
 		@Override

--- a/openstack-client-connectors/jersey2-connector/src/main/java/com/woorea/openstack/connector/OpenStack.java
+++ b/openstack-client-connectors/jersey2-connector/src/main/java/com/woorea/openstack/connector/OpenStack.java
@@ -73,6 +73,7 @@ public class OpenStack {
 			DEFAULT_MAPPER.enable(SerializationConfig.Feature.INDENT_OUTPUT);
 			DEFAULT_MAPPER.enable(DeserializationConfig.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
 			DEFAULT_MAPPER.disable(DeserializationConfig.Feature.FAIL_ON_UNKNOWN_PROPERTIES);
+			DEFAULT_MAPPER.enable(DeserializationConfig.Feature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT);
 			
 			WRAPPED_MAPPER = new ObjectMapper();
 			
@@ -82,6 +83,7 @@ public class OpenStack {
 			WRAPPED_MAPPER.enable(DeserializationConfig.Feature.UNWRAP_ROOT_VALUE);
 			WRAPPED_MAPPER.enable(DeserializationConfig.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
 			WRAPPED_MAPPER.disable(DeserializationConfig.Feature.FAIL_ON_UNKNOWN_PROPERTIES);
+			WRAPPED_MAPPER.enable(DeserializationConfig.Feature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT);
 			
 			CLIENT.register(new JacksonFeature()).register(new ContextResolver<ObjectMapper>() {
 

--- a/openstack-client-connectors/resteasy-connector/src/main/java/com/woorea/openstack/connector/RESTEasyConnector.java
+++ b/openstack-client-connectors/resteasy-connector/src/main/java/com/woorea/openstack/connector/RESTEasyConnector.java
@@ -64,6 +64,7 @@ public class RESTEasyConnector implements OpenStackClientConnector {
 		DEFAULT_MAPPER.enable(SerializationConfig.Feature.INDENT_OUTPUT);
 		DEFAULT_MAPPER.enable(DeserializationConfig.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
 		DEFAULT_MAPPER.disable(DeserializationConfig.Feature.FAIL_ON_UNKNOWN_PROPERTIES);
+		DEFAULT_MAPPER.enable(DeserializationConfig.Feature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT);
 
 		WRAPPED_MAPPER = new ObjectMapper();
 
@@ -73,6 +74,7 @@ public class RESTEasyConnector implements OpenStackClientConnector {
 		WRAPPED_MAPPER.enable(DeserializationConfig.Feature.UNWRAP_ROOT_VALUE);
 		WRAPPED_MAPPER.enable(DeserializationConfig.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
 		WRAPPED_MAPPER.disable(DeserializationConfig.Feature.FAIL_ON_UNKNOWN_PROPERTIES);
+		WRAPPED_MAPPER.enable(DeserializationConfig.Feature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT);
 
 		providerFactory = new OpenStackProviderFactory();
 	}


### PR DESCRIPTION
Connectors used to throw an error deserializing an empty string, e.g.,
a “image” : “” returned as part of a Server description when the Server
was not booted from an Image.  Now, this example returns a null Image
object.
