### PR TITLE
Update OpenStackResponseException to be able to hold original response entity

### DIFF
--- a/openstack-client-connectors/jersey-connector/src/main/java/com/woorea/openstack/connector/JerseyResponse.java
+++ b/openstack-client-connectors/jersey-connector/src/main/java/com/woorea/openstack/connector/JerseyResponse.java
@@ -3,6 +3,7 @@ package com.woorea.openstack.connector;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Scanner;
 
 import com.sun.jersey.api.client.ClientResponse;
 import com.woorea.openstack.base.client.OpenStackResponse;
@@ -19,8 +20,14 @@ public class JerseyResponse implements OpenStackResponse {
 	@Override
 	public <T> T getEntity(Class<T> returnType) {
 		if(response.getStatus() >= 400) {
-			throw new OpenStackResponseException(response.getClientResponseStatus().getReasonPhrase(), 
-					response.getStatus());
+			String responseEntity = null;
+			if(response.hasEntity()) {
+				Scanner scanner = new Scanner(response.getEntityInputStream());
+				scanner.useDelimiter("\\A");
+				responseEntity = scanner.next();
+				scanner.close();
+			}
+			throw new OpenStackResponseException(response.getClientResponseStatus().getReasonPhrase(), responseEntity, response.getStatus());
 		}
 		if(response.hasEntity() && returnType != null && Void.class != returnType) {
 			return response.getEntity(returnType);

--- a/openstack-client/src/main/java/com/woorea/openstack/base/client/OpenStackResponseException.java
+++ b/openstack-client/src/main/java/com/woorea/openstack/base/client/OpenStackResponseException.java
@@ -5,7 +5,7 @@ public class OpenStackResponseException extends RuntimeException {
 	private static final long serialVersionUID = 7294957362769575271L;
 
 	protected String message;
-
+	protected String fullMessage;
 	protected int status;
 
 	public OpenStackResponseException(String message, int status) {
@@ -13,8 +13,18 @@ public class OpenStackResponseException extends RuntimeException {
 		this.status = status;
 	}
 
+	public OpenStackResponseException(String message, String fullMessage, int status) {
+		this.message = message;
+		this.status = status;
+		this.fullMessage = fullMessage;
+	}
+
 	public String getMessage() {
 		return message;
+	}
+
+	public String getFullMessage() {
+		return fullMessage;
 	}
 
 	public int getStatus() {


### PR DESCRIPTION
In the event of a 4xx or 5xx error, return more detailed error response exception. Current implementation merely returns status code and human readable description for status code (Ie. 400 and Bad Request).
