### PR TITLE
Add audit_ids field to keystone token model to avoid problems on Juno

### DIFF
--- a/keystone-model/src/main/java/com/woorea/openstack/keystone/model/Token.java
+++ b/keystone-model/src/main/java/com/woorea/openstack/keystone/model/Token.java
@@ -1,7 +1,10 @@
 package com.woorea.openstack.keystone.model;
 
+import org.codehaus.jackson.annotate.JsonIgnoreProperties;
+
 import java.util.Calendar;
 
+@JsonIgnoreProperties(ignoreUnknown=true)
 public final class Token {
 
 	private String id;


### PR DESCRIPTION
In case the library is used against Juno Release of Keystone, an UnrecognizedPropertyException could be thrown about audit_ids field not being declared as part of the Keystone Token, to solve this problem we declare it as a field of the token.