### PR TITLE
Don't expect a response body for resize and confirm-resize operations on a server resource

### DIFF
--- a/nova-client/src/main/java/com/woorea/openstack/nova/api/ServersResource.java
+++ b/nova-client/src/main/java/com/woorea/openstack/nova/api/ServersResource.java
@@ -224,12 +224,12 @@ public class ServersResource {
 		return new RebuildAction(serverId, rebuild);
 	}
 
-	public class ResizeAction extends Action<Server> {
+	public class ResizeAction extends Action<Void> {
 
 		private Resize action;
 
 		public ResizeAction(String id, Resize action) {
-			super(id, Entity.json(action), Server.class);
+			super(id, Entity.json(action), Void.class);
 		}
 
 	}
@@ -241,10 +241,10 @@ public class ServersResource {
 	    return new ResizeAction(serverId, resize);
 	  }
 
-	public class ConfirmResizeAction extends Action<Server> {
+	public class ConfirmResizeAction extends Action<Void> {
 
 		public ConfirmResizeAction(String id) {
-			super(id, Entity.json(new ConfirmResize()), Server.class);
+			super(id, Entity.json(new ConfirmResize()), Void.class);
 		}
 
 	}


### PR DESCRIPTION
While using the resize() operation (and confirmResize()) on the ServersResource, we ran into an exception which looked like this:

        INFO: 1 * LoggingFilter - Request received on thread main
        1 > POST http://192.168.0.122:8774/v2/a9bfb1b2425540df335232/servers/091sdscf1-6623-4c82-9015-5cf323acd6e29/action
        1 > X-Auth-Token: xxxxx
        1 > Accept: application/json
        1 > Content-Type: application/json
        {
          "resize" : {
            "flavorRef" : "4",
            "OS-DCF:diskConfig" : "MANUAL"
          }
        }

        Jul 13, 2015 5:04:31 PM org.glassfish.jersey.filter.LoggingFilter log
        INFO: 2 * LoggingFilter - Response received on thread main
        2 < 202
        2 < Date: Mon, 13 Jul 2015 11:34:56 GMT
        2 < Content-Length: 0
        2 < Connection: close
        2 < Content-Type: text/html; charset=UTF-8
        2 < X-Compute-Request-Id: ....

        Exception in thread "main" org.glassfish.jersey.message.internal.MessageBodyProviderNotFoundException: MessageBodyReader not found for media type=text/html; charset=UTF-8, type=class com.woorea.openstack.nova.model.Server, genericType=class com.woorea.openstack.nova.model.Server.
            at org.glassfish.jersey.message.internal.ReaderInterceptorExecutor$TerminalReaderInterceptor.aroundReadFrom(ReaderInterceptorExecutor.java:173)
            at org.glassfish.jersey.message.internal.ReaderInterceptorExecutor.proceed(ReaderInterceptorExecutor.java:134)
            at org.glassfish.jersey.message.internal.MessageBodyFactory.readFrom(MessageBodyFactory.java:828)
            at org.glassfish.jersey.message.internal.InboundMessageContext.readEntity(InboundMessageContext.java:833)
            at org.glassfish.jersey.message.internal.InboundMessageContext.readEntity(InboundMessageContext.java:768)
            at org.glassfish.jersey.client.InboundJaxrsResponse.readEntity(InboundJaxrsResponse.java:96)
            at org.glassfish.jersey.client.ScopedJaxrsResponse.access$001(ScopedJaxrsResponse.java:56)
            at org.glassfish.jersey.client.ScopedJaxrsResponse$1.call(ScopedJaxrsResponse.java:77)
            at org.glassfish.jersey.internal.Errors.process(Errors.java:275)
            at org.glassfish.jersey.internal.Errors.process(Errors.java:257)
            at org.glassfish.jersey.internal.Errors.process(Errors.java:188)
            at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:396)
            at org.glassfish.jersey.client.ScopedJaxrsResponse.readEntity(ScopedJaxrsResponse.java:74)
            at com.woorea.openstack.connector.JaxRs20Response.getEntity()
            at com.woorea.openstack.base.client.OpenStackClient.execute()
            at com.woorea.openstack.base.client.OpenStackClient.execute()
            at com.woorea.openstack.base.client.OpenStackRequest.execute()

The stacktrace suggests that the implementation is trying to read the response body expecting some content where as the OpenStack documentation (http://developer.openstack.org/api-ref-compute-v2.html) for these resize and confirmResize API says that:

>> This operation does not return a response body. 

The changes in this commit includes a fix to this issue, by making the resize and confirm resize actions, not expect any response body. This change got us past the issue we were running into.

