### PR TITLE
Customized executor for RESTEasyConnector

### DIFF
--- a/openstack-client-connectors/resteasy-connector/src/main/java/com/woorea/openstack/connector/RESTEasyConnector.java
+++ b/openstack-client-connectors/resteasy-connector/src/main/java/com/woorea/openstack/connector/RESTEasyConnector.java
@@ -14,6 +14,7 @@ import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.map.SerializationConfig;
 import org.codehaus.jackson.map.annotate.JsonRootName;
 import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
+import org.jboss.resteasy.client.ClientExecutor;
 import org.jboss.resteasy.client.ClientRequest;
 import org.jboss.resteasy.client.ClientResponse;
 import org.jboss.resteasy.plugins.providers.InputStreamProvider;
@@ -79,9 +80,13 @@ public class RESTEasyConnector implements OpenStackClientConnector {
 		providerFactory = new OpenStackProviderFactory();
 	}
 
+	protected ClientExecutor createClientExecutor() {
+		return ClientRequest.getDefaultExecutor();
+	}
+
 	public <T> OpenStackResponse request(OpenStackRequest<T> request) {
 		ClientRequest client = new ClientRequest(UriBuilder.fromUri(request.endpoint() + "/" + request.path()),
-				ClientRequest.getDefaultExecutor(), providerFactory);
+				createClientExecutor(), providerFactory);
 
 		for(Map.Entry<String, List<Object> > entry : request.queryParams().entrySet()) {
 			for (Object o : entry.getValue()) {


### PR DESCRIPTION
The RESTEasyConnector is modified to enables the usage of a customized executor for the request.
Please find an example how to use a customized executor in [QuantumListNetworksTimeout.java](https://github.com/dominikholler/openstack-java-sdk/blob/a1e5b455156a9adb023efffc39e2707f9ed50470/openstack-examples/src/main/java/com/woorea/openstack/examples/network/QuantumListNetworksTimeout.java)