### PR TITLE
RESTEasyConnector: Isolate the creation of ClientExecutor

### DIFF
--- a/openstack-client-connectors/resteasy-connector/src/main/java/com/woorea/openstack/connector/RESTEasyConnector.java
+++ b/openstack-client-connectors/resteasy-connector/src/main/java/com/woorea/openstack/connector/RESTEasyConnector.java
@@ -14,6 +14,7 @@ import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.map.SerializationConfig;
 import org.codehaus.jackson.map.annotate.JsonRootName;
 import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
+import org.jboss.resteasy.client.ClientExecutor;
 import org.jboss.resteasy.client.ClientRequest;
 import org.jboss.resteasy.client.ClientResponse;
 import org.jboss.resteasy.plugins.providers.InputStreamProvider;
@@ -77,9 +78,13 @@ public class RESTEasyConnector implements OpenStackClientConnector {
 		providerFactory = new OpenStackProviderFactory();
 	}
 
+	protected ClientExecutor createClientExecutor() {
+		return ClientRequest.getDefaultExecutor();
+	}
+
 	public <T> OpenStackResponse request(OpenStackRequest<T> request) {
 		ClientRequest client = new ClientRequest(UriBuilder.fromUri(request.endpoint() + "/" + request.path()),
-				ClientRequest.getDefaultExecutor(), providerFactory);
+				createClientExecutor(), providerFactory);
 
 		for(Map.Entry<String, List<Object> > entry : request.queryParams().entrySet()) {
 			for (Object o : entry.getValue()) {


### PR DESCRIPTION
The creation of the ClientExecutor is isolated in a protected method,
to allow subclasses to overwrite.

This enables the usage of a customized executor for the request.
The customized executor is needed to set parameters, like timeouts,
on the creation of the executor.

(cherry picked from commit 23922741ab80dc665f83362fbc7b14e8af0240a3)