### PR TITLE
Let all request path start with "/"

### DIFF
--- a/nova-client/src/main/java/com/woorea/openstack/nova/api/ExtensionsResource.java
+++ b/nova-client/src/main/java/com/woorea/openstack/nova/api/ExtensionsResource.java
@@ -21,7 +21,7 @@ public class ExtensionsResource {
 	public class List extends OpenStackRequest<Extensions> {
 
 	    public List(boolean detail) {
-	    	super(CLIENT, HttpMethod.GET, detail ? "extensions/detail" : "extensions", null, Extensions.class);
+	        super(CLIENT, HttpMethod.GET, detail ? buildPath("extensions", "detail") : buildPath("extensions"), null, Extensions.class);
 	    }
 	    
 	 }

--- a/openstack-client-connectors/resteasy-connector/src/main/java/com/woorea/openstack/connector/RESTEasyConnector.java
+++ b/openstack-client-connectors/resteasy-connector/src/main/java/com/woorea/openstack/connector/RESTEasyConnector.java
@@ -85,7 +85,7 @@ public class RESTEasyConnector implements OpenStackClientConnector {
 	}
 
 	public <T> OpenStackResponse request(OpenStackRequest<T> request) {
-		ClientRequest client = new ClientRequest(UriBuilder.fromUri(request.endpoint() + "/" + request.path()),
+		ClientRequest client = new ClientRequest(UriBuilder.fromUri(request.endpoint() + request.path()),
 				createClientExecutor(), providerFactory);
 
 		for(Map.Entry<String, List<Object> > entry : request.queryParams().entrySet()) {

--- a/openstack-client/src/main/java/com/woorea/openstack/base/client/OpenStackRequest.java
+++ b/openstack-client/src/main/java/com/woorea/openstack/base/client/OpenStackRequest.java
@@ -133,7 +133,9 @@ public class OpenStackRequest<R> {
 	
 	protected static String buildPath(String ... elements) {
 	    StringBuilder stringBuilder = new StringBuilder();
+	    final String PATH_SEPARATOR = "/";
 	    for (String element : elements) {
+            stringBuilder.append(PATH_SEPARATOR);
             stringBuilder.append(element);
         }
 

--- a/quantum-client/src/main/java/com/woorea/openstack/quantum/api/NetworksResource.java
+++ b/quantum-client/src/main/java/com/woorea/openstack/quantum/api/NetworksResource.java
@@ -39,7 +39,7 @@ public class NetworksResource {
 	public class List extends OpenStackRequest<Networks> {
 
 		public List() {
-		    super(CLIENT, HttpMethod.GET, "networks", null, Networks.class);
+		    super(CLIENT, HttpMethod.GET, buildPath("networks"), null, Networks.class);
 		}
 	}
 
@@ -57,28 +57,28 @@ public class NetworksResource {
 	public class Create extends OpenStackRequest<Network> {
 
         public Create(Network net) {
-		    super(CLIENT, HttpMethod.POST, "networks", Entity.json(net), Network.class);
+		    super(CLIENT, HttpMethod.POST, buildPath("networks"), Entity.json(net), Network.class);
 		}
 	}
 
     public class Update extends OpenStackRequest<Network> {
 
         public Update(Network net) {
-            super(CLIENT, HttpMethod.PUT, buildPath("networks/", net.getId()), Entity.json(net), Network.class);
+            super(CLIENT, HttpMethod.PUT, buildPath("networks", net.getId()), Entity.json(net), Network.class);
         }
     }
 
 	public class Show extends OpenStackRequest<Network> {
 
 		public Show(String id) {
-		    super(CLIENT, HttpMethod.GET, buildPath("networks/", id), null, Network.class);
+		    super(CLIENT, HttpMethod.GET, buildPath("networks", id), null, Network.class);
 		}
 	}
 
 	public class Delete extends OpenStackRequest<Void> {
 
 		public Delete(String id){
-		    super(CLIENT, HttpMethod.DELETE, buildPath("networks/", id), null, Void.class);
+		    super(CLIENT, HttpMethod.DELETE, buildPath("networks", id), null, Void.class);
 		}
 	}
 }

--- a/quantum-client/src/main/java/com/woorea/openstack/quantum/api/PortsResource.java
+++ b/quantum-client/src/main/java/com/woorea/openstack/quantum/api/PortsResource.java
@@ -39,7 +39,7 @@ public class PortsResource {
 	public class List extends OpenStackRequest<Ports> {
 
 		public List() {
-		    super(CLIENT, HttpMethod.GET, "ports", null, Ports.class);
+		    super(CLIENT, HttpMethod.GET, buildPath("ports"), null, Ports.class);
 		}
 	}
 
@@ -58,28 +58,28 @@ public class PortsResource {
 	public class Create extends OpenStackRequest<Port> {
 
 		public Create(Port port){
-		    super(CLIENT, HttpMethod.POST, "ports", Entity.json(port), Port.class);
+		    super(CLIENT, HttpMethod.POST, buildPath("ports"), Entity.json(port), Port.class);
 		}
 	}
 
 	public class Update extends OpenStackRequest<Port> {
 
 	    public Update(Port port){
-	        super(CLIENT, HttpMethod.PUT, buildPath("ports/", port.getId()), Entity.json(port), Port.class);
+	        super(CLIENT, HttpMethod.PUT, buildPath("ports", port.getId()), Entity.json(port), Port.class);
 	    }
 	}
 
 	public class Show extends OpenStackRequest<Port> {
 
 		public Show(String id) {
-		    super(CLIENT, HttpMethod.GET, buildPath("ports/", id), null, Port.class);
+		    super(CLIENT, HttpMethod.GET, buildPath("ports", id), null, Port.class);
 		}
 	}
 
 	public class Delete extends OpenStackRequest<Void> {
 
 		public Delete(String id){
-            super(CLIENT, HttpMethod.DELETE, buildPath("ports/", id), null, Void.class);
+            super(CLIENT, HttpMethod.DELETE, buildPath("ports", id), null, Void.class);
 		}
 	}
 }

--- a/quantum-client/src/main/java/com/woorea/openstack/quantum/api/RoutersResource.java
+++ b/quantum-client/src/main/java/com/woorea/openstack/quantum/api/RoutersResource.java
@@ -37,7 +37,7 @@ public class RoutersResource {
 		public class List extends OpenStackRequest<Routers> {
 
 			public List() {
-			    super(CLIENT, HttpMethod.GET, "routers", null, Routers.class);
+			    super(CLIENT, HttpMethod.GET, buildPath("routers"), null, Routers.class);
 			}
 		}
 
@@ -53,7 +53,7 @@ public class RoutersResource {
 		public class Create extends OpenStackRequest<Router> {
 
 			public Create(RouterForCreate router){
-			    super(CLIENT, HttpMethod.POST, "routers", Entity.json(router), Router.class);
+			    super(CLIENT, HttpMethod.POST, buildPath("routers"), Entity.json(router), Router.class);
 			}
 		}
 
@@ -62,14 +62,14 @@ public class RoutersResource {
 		public class Show extends OpenStackRequest<Router> {
 
 			public Show(String id) {
-			    super(CLIENT, HttpMethod.GET, buildPath("routers/", id), null, Router.class);
+			    super(CLIENT, HttpMethod.GET, buildPath("routers", id), null, Router.class);
 			}
 		}
 
 		public class Delete extends OpenStackRequest<Void> {
 
 			public Delete(String id){
-			    super(CLIENT, HttpMethod.DELETE, buildPath("routers/", id), null, Void.class);
+			    super(CLIENT, HttpMethod.DELETE, buildPath("routers", id), null, Void.class);
 			}
 		}
 		public Attach addInterface(RouterForAddInterface interfaceToAdd){
@@ -78,7 +78,7 @@ public class RoutersResource {
 		public class Attach extends OpenStackRequest<RouterInterface> {
 
 			public Attach(RouterForAddInterface interfaceToAdd){
-			    super(CLIENT, HttpMethod.PUT, buildPath("routers/",interfaceToAdd.getRouterId(),"/add_router_interface"), Entity.json(interfaceToAdd),RouterInterface.class);
+			    super(CLIENT, HttpMethod.PUT, buildPath("routers",interfaceToAdd.getRouterId(),"add_router_interface"), Entity.json(interfaceToAdd),RouterInterface.class);
 			}	
 			
 		}
@@ -89,8 +89,8 @@ public class RoutersResource {
 		public class Detach extends OpenStackRequest<RouterInterface> {
 
 		public Detach(RouterForAddInterface interfaceToAdd) {
-			super(CLIENT, HttpMethod.PUT, buildPath("routers/",
-					interfaceToAdd.getRouterId(), "/remove_router_interface"),
+			super(CLIENT, HttpMethod.PUT, buildPath("routers",
+					interfaceToAdd.getRouterId(), "remove_router_interface"),
 					Entity.json(interfaceToAdd), RouterInterface.class);
 		}
 

--- a/quantum-client/src/main/java/com/woorea/openstack/quantum/api/SubnetsResource.java
+++ b/quantum-client/src/main/java/com/woorea/openstack/quantum/api/SubnetsResource.java
@@ -39,7 +39,7 @@ public class SubnetsResource {
 	public class List extends OpenStackRequest<Subnets> {
 
 		public List() {
-		    super(CLIENT, HttpMethod.GET, "subnets", null, Subnets.class);
+		    super(CLIENT, HttpMethod.GET, buildPath("subnets"), null, Subnets.class);
 		}
 	}
 
@@ -57,28 +57,28 @@ public class SubnetsResource {
 	public class Create extends OpenStackRequest<Subnet> {
 
         public Create(Subnet subnet) {
-		    super(CLIENT, HttpMethod.POST, "subnets", Entity.json(subnet), Subnet.class);
+		    super(CLIENT, HttpMethod.POST, buildPath("subnets"), Entity.json(subnet), Subnet.class);
 		}
 	}
 
     public class Update extends OpenStackRequest<Subnet> {
 
         public Update(Subnet subnet) {
-            super(CLIENT, HttpMethod.PUT, buildPath("subnets/", subnet.getId()), Entity.json(subnet), Subnet.class);
+            super(CLIENT, HttpMethod.PUT, buildPath("subnets", subnet.getId()), Entity.json(subnet), Subnet.class);
         }
     }
 
 	public class Show extends OpenStackRequest<Subnet> {
 
 		public Show(String id) {
-            super(CLIENT, HttpMethod.GET, buildPath("subnets/", id), null, Subnet.class);
+            super(CLIENT, HttpMethod.GET, buildPath("subnets", id), null, Subnet.class);
 		}
 	}
 
 	public class Delete extends OpenStackRequest<Void> {
 
 		public Delete(String id){
-            super(CLIENT, HttpMethod.DELETE, buildPath("subnets/", id), null, Void.class);
+            super(CLIENT, HttpMethod.DELETE, buildPath("subnets", id), null, Void.class);
 		}
 	}
 }


### PR DESCRIPTION
The convention that the path of an OpenStackRequest starts with an
"/" or is empty is introduced. The majority of the code was
written before this change according this convention anyway.
This way the resteasy-connector does not need to add the "/"
between the endpoint and the path. This way the generated URLs
does not contain unintended double "/" anymore, which may
confuse the OpenStack server.

@simon3z @woorea do you think this is a good way to get rid of the double slashes?