### PR TITLE
Revert "Add sonatype.org to pom.xml"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,17 +131,6 @@
 				<artifactId>maven-resources-plugin</artifactId>
 				<version>2.6</version>
 			</plugin>
-			<plugin>
-				<groupId>org.sonatype.plugins</groupId>
-				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.7</version>
-				<extensions>true</extensions>
-				<configuration>
-					<serverId>ossrh</serverId>
-					<nexusUrl>https://oss.sonatype.org/</nexusUrl>
-					<autoReleaseAfterClose>false</autoReleaseAfterClose>
-				</configuration>
-			</plugin>
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
This reverts commit 32053dbebdf3c686a1ad484c325f8afc15c17c2a.

The nexus-staging-maven-plugin causes trouble in fedora's
build system, and might cause trouble in other build systems,
too.