### PR TITLE
Align required versions

### DIFF
--- a/openstack-client-connectors/jersey-connector/pom.xml
+++ b/openstack-client-connectors/jersey-connector/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.woorea</groupId>
     <artifactId>openstack-client-connectors</artifactId>
-    <version>3.2.2-SNAPSHOT</version>
+    <version>3.2.4-SNAPSHOT</version>
   </parent>
   <artifactId>jersey-connector</artifactId>
   <name>OpenStack Jersey Connector</name>

--- a/openstack-examples/pom.xml
+++ b/openstack-examples/pom.xml
@@ -5,6 +5,10 @@
     <artifactId>openstack-java-sdk</artifactId>
     <version>3.2.4-SNAPSHOT</version>
   </parent>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <openstack-sdk.version>3.2.4-SNAPSHOT</openstack-sdk.version>
+  </properties>
   <artifactId>openstack-examples</artifactId>
   <name>OpenStack Examples</name>
   <description>OpenStack Examples</description>
@@ -12,37 +16,37 @@
   	<dependency>
   		<groupId>com.woorea</groupId>
   		<artifactId>keystone-client</artifactId>
-  		<version>3.2.4-SNAPSHOT</version>
+  		<version>${openstack-sdk.version}</version>
   	</dependency>
   	<dependency>
   		<groupId>com.woorea</groupId>
   		<artifactId>nova-client</artifactId>
-  		<version>3.2.4-SNAPSHOT</version>
+  		<version>${openstack-sdk.version}</version>
   	</dependency>
       <dependency>
           <groupId>com.woorea</groupId>
           <artifactId>heat-client</artifactId>
-          <version>3.2.4-SNAPSHOT</version>
+          <version>${openstack-sdk.version}</version>
       </dependency>
   	<dependency>
   		<groupId>com.woorea</groupId>
   		<artifactId>swift-client</artifactId>
-  		<version>3.2.4-SNAPSHOT</version>
+  		<version>${openstack-sdk.version}</version>
   	</dependency>
 	<dependency>
 		<groupId>com.woorea</groupId>
 		<artifactId>quantum-client</artifactId>
-		<version>3.2.4-SNAPSHOT</version>
+		<version>${openstack-sdk.version}</version>
 	</dependency>
 	<dependency>
 		<groupId>com.woorea</groupId>
 		<artifactId>ceilometer-client</artifactId>
-		<version>3.2.4-SNAPSHOT</version>
+		<version>${openstack-sdk.version}</version>
 	</dependency>
 	<dependency>
 		<groupId>com.woorea</groupId>
 		<artifactId>glance-client</artifactId>
-		<version>3.2.4-SNAPSHOT</version>
+		<version>${openstack-sdk.version}</version>
 	</dependency>
   </dependencies>
   <profiles>
@@ -52,7 +56,7 @@
 			<dependency>
 				<groupId>com.woorea</groupId>
 				<artifactId>jersey-connector</artifactId>
-				<version>3.0.0-SNAPSHOT</version>
+				<version>${openstack-sdk.version}</version>
 			</dependency>
 		</dependencies>
 	</profile>
@@ -65,7 +69,7 @@
 			<dependency>
 				<groupId>com.woorea</groupId>
 				<artifactId>jersey2-connector</artifactId>
-				<version>3.1.0-SNAPSHOT</version>
+				<version>${openstack-sdk.version}</version>
 			</dependency>
 		</dependencies>
 	</profile>
@@ -75,7 +79,7 @@
 			<dependency>
 				<groupId>com.woorea</groupId>
 				<artifactId>resteasy-connector</artifactId>
-				<version>3.1.0-SNAPSHOT</version>
+				<version>${openstack-sdk.version}</version>
 			</dependency>
 		</dependencies>
 	</profile>


### PR DESCRIPTION
The examples and the jersey-connector reference the current
version of openstack-java-sdk.
