### PR TITLE
Implement the port_security_enabled attribute for neutron networks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# 3.2.5 / 2018-11-14
+* neutron: Add support for `port_security_enabled` on Networks
+
 # 3.2.4 / 2018
 * Improved backward compatibility to 3.1.3
 

--- a/quantum-model/src/main/java/com/woorea/openstack/quantum/model/Network.java
+++ b/quantum-model/src/main/java/com/woorea/openstack/quantum/model/Network.java
@@ -43,6 +43,9 @@ public class Network implements Serializable {
 
     private Integer mtu;
 
+    @JsonProperty("port_security_enabled")
+    private Boolean portSecurityEnabled;
+
     /**
      * @return the status
      */
@@ -276,6 +279,26 @@ public class Network implements Serializable {
         this.mtu = mtu;
     }
 
+    /**
+     * @return the portSecurityEnabled
+     */
+    @JsonIgnore
+    public boolean isPortSecurityEnabled() {
+        return portSecurityEnabled;
+    }
+
+    public Boolean getPortSecurityEnabled() {
+        return portSecurityEnabled;
+    }
+
+    /**
+     *
+     * @param portSecurityEnabled enable / disable the default portSecurityEnabled for all future ports in this network
+     */
+    public void setPortSecurityEnabled(Boolean portSecurityEnabled) {
+        this.portSecurityEnabled = portSecurityEnabled;
+    }
+
     /*
      * (non-Javadoc)
      *
@@ -287,6 +310,7 @@ public class Network implements Serializable {
                 + subnets + ", status=" + status + ", admin_state_up=" + adminStateUp + ", tenant_id=" +
                 tenantId + ", shared=" + shared + ", mtu=" + mtu + ", provider:physical_network=" +
                 providerPhysicalNetwork + ", provider:network_type=" + providerNetworkType + ", router:external=" +
-                routerExternal + ", provider:segmentation_id=" + providerSegmentationId + "]";
+                routerExternal + ", provider:segmentation_id=" + providerSegmentationId +
+                ", port_security_enabled=" + portSecurityEnabled + "]";
     }
 }

--- a/quantum-model/src/test/java/com/woorea/openstack/quantum/model/NetworkTest.java
+++ b/quantum-model/src/test/java/com/woorea/openstack/quantum/model/NetworkTest.java
@@ -37,6 +37,8 @@ public class NetworkTest {
 
     private static final String ROUTER_EXTERNAL = "routerExternal";
 
+    private static final Boolean PORT_SECURITY_ENABLED = Boolean.FALSE;
+
     /**
      * JSON with read only attributes.
      */
@@ -70,6 +72,7 @@ public class NetworkTest {
         network.setName(NAME);
         network.setShared(SHARED);
         network.setTenantId(TENANT_ID);
+        network.setPortSecurityEnabled(PORT_SECURITY_ENABLED);
 
         serializedNetwork = objectMapper.writeValueAsString(network);
         assertThat(serializedNetwork, not(containsString(ID)));
@@ -83,6 +86,7 @@ public class NetworkTest {
         assertThat(serializedNetwork, containsString(PROVIDER_NETWORK_TYPE));
         assertThat(serializedNetwork, containsString(PROVIDER_PHYSICAL_NETWORK));
         assertThat(serializedNetwork, containsString(Integer.toString(PROVIDER_SEGMENTATION_ID)));
+        assertThat(serializedNetwork, containsString("\"port_security_enabled\" : " + PORT_SECURITY_ENABLED));
     }
 
     @Test
@@ -115,5 +119,6 @@ public class NetworkTest {
         assertThat(network.getProviderNetworkType(), is(equalTo(PROVIDER_NETWORK_TYPE)));
         assertThat(network.getProviderPhysicalNetwork(), is(equalTo(PROVIDER_PHYSICAL_NETWORK)));
         assertThat(network.getProviderSegmentationId(), is(equalTo(PROVIDER_SEGMENTATION_ID)));
+        assertThat(network.getPortSecurityEnabled(), is(equalTo(PORT_SECURITY_ENABLED)));
     }
 }


### PR DESCRIPTION
The port_security_enabled attribute is used to specify the default
port security value of all ports created in the given network.